### PR TITLE
Upgrade H5Web and add support for 7 compression plugins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
 - [Development](#development)
   - [`pnpm` cheat sheet](#pnpm-cheat-sheet)
   - [Dependency management](#dependency-management)
+    - [DefinitelyTyped packages](#definitelytyped-packages)
 - [Build](#build)
 - [Code quality](#sode-quality)
   - [Automatic fixing and formatting](#automatic-fixing-and-formatting)
@@ -45,11 +46,18 @@ pnpm start
    `pnpm install` (but make sure to specify an exact dependency version rather
    than a range – i.e. don't prefix the version with a caret or a tilde).
 
-> Note that `react` and `react-dom` must remain at v17 until H5Web supports v18.
-
 > If you run into peer dependency warnings and other package resolution issues,
 > note that `pnpm` offers numerous solutions for dealing with them, like
 > [`pnpm.peerDependencyRules.allowedVersions`](https://pnpm.io/package_json#pnpmpeerdependencyrulesallowedversions).
+
+#### [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) packages
+
+The major versions of `@types/*` packages must be aligned with the major
+versions of the packages they provide types for—i.e. `foo@x.y.z` requires
+`@types/foo@^x`.
+
+For convenience, `@types` packages can be quickly upgraded to their latest
+minor/patch version by running `pnpm up`.
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@h5web/app": "10.1.0",
     "@h5web/h5wasm": "10.1.0",
     "@react-hookz/web": "15.1.0",
+    "h5wasm-plugins": "0.0.3",
     "immer": "9.0.15",
     "normalize.css": "8.0.1",
     "react": "18.2.0",
@@ -49,9 +50,10 @@
     "eslint": "8.21.0",
     "eslint-config-galex": "4.1.7",
     "npm-run-all": "4.1.5",
-    "prettier": "3.0.3",
+    "prettier": "3.1.1",
     "typescript": "4.7.4",
     "vite": "3.1.1",
+    "vite-plugin-checker": "0.6.2",
     "vite-plugin-eslint": "1.8.1"
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "https://gitlab.esrf.fr/ui/myhdf5"
   },
   "engines": {
-    "node": "18.x",
-    "pnpm": ">=8.6.0"
+    "node": "20.x",
+    "pnpm": "8.x"
   },
   "type": "module",
   "scripts": {
@@ -25,8 +25,8 @@
     "analyze": "npx source-map-explorer 'build/static/js/*.js'"
   },
   "dependencies": {
-    "@h5web/app": "10.0.0",
-    "@h5web/h5wasm": "10.0.0",
+    "@h5web/app": "10.1.0",
+    "@h5web/h5wasm": "10.1.0",
     "@react-hookz/web": "15.1.0",
     "immer": "9.0.15",
     "normalize.css": "8.0.1",
@@ -41,7 +41,7 @@
     "zustand": "4.0.0"
   },
   "devDependencies": {
-    "@types/node": "^18.18.6",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
     "@vitejs/plugin-react": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 dependencies:
   '@h5web/app':
-    specifier: 10.0.0
-    version: 10.0.0(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.7.4)
+    specifier: 10.1.0
+    version: 10.1.0(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.7.4)
   '@h5web/h5wasm':
-    specifier: 10.0.0
-    version: 10.0.0(@h5web/app@10.0.0)(react@18.2.0)(typescript@4.7.4)
+    specifier: 10.1.0
+    version: 10.1.0(@h5web/app@10.1.0)(react@18.2.0)(typescript@4.7.4)
   '@react-hookz/web':
     specifier: 15.1.0
     version: 15.1.0(react-dom@18.2.0)(react@18.2.0)
@@ -50,8 +50,8 @@ dependencies:
 
 devDependencies:
   '@types/node':
-    specifier: ^18.18.6
-    version: 18.18.6
+    specifier: ^20.10.5
+    version: 20.10.5
   '@types/react':
     specifier: ^18.2.31
     version: 18.2.31
@@ -1692,8 +1692,8 @@ packages:
       - supports-color
     dev: true
 
-  /@h5web/app@10.0.0(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.7.4):
-    resolution: {integrity: sha512-50qD9DUy/VydKoOPOMrC+cCE/22qkyrXxsaYAmRbFZSvvbxbuICbg3O/roVeBdtY/UYZ8/w1CZiSQS/2LnCJRw==}
+  /@h5web/app@10.1.0(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.7.4):
+    resolution: {integrity: sha512-M0PDOFeCikcC/BGMbr4opsd5vEQgAtj83Gc2egmhF1MVjTdFBvl9YipdaLRlLnDpmK/xMOXwuoE5vbxqCvBS6g==}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
@@ -1702,10 +1702,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@h5web/lib': 10.0.0(@react-three/fiber@8.14.1)(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(three@0.156.1)(typescript@4.7.4)
+      '@h5web/lib': 10.1.0(@react-three/fiber@8.15.12)(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(three@0.159.0)(typescript@4.7.4)
       '@react-hookz/web': 23.1.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-three/fiber': 8.14.1(react-dom@18.2.0)(react@18.2.0)(three@0.156.1)
-      axios: 1.5.0
+      '@react-three/fiber': 8.15.12(react-dom@18.2.0)(react@18.2.0)(three@0.159.0)
+      axios: 1.6.2
       d3-format: 3.1.0
       lodash: 4.17.21
       ndarray: 1.0.19
@@ -1713,13 +1713,13 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-error-boundary: 4.0.11(react@18.2.0)
-      react-icons: 4.11.0(react@18.2.0)
+      react-icons: 4.12.0(react@18.2.0)
       react-reflex: 4.1.0(react-dom@18.2.0)(react@18.2.0)
       react-slider: 2.0.4(react@18.2.0)
       react-suspense-fetch: 0.4.1
-      three: 0.156.1
+      three: 0.159.0
       typescript: 4.7.4
-      zustand: 4.4.1(@types/react@18.2.31)(immer@9.0.15)(react@18.2.0)
+      zustand: 4.4.7(@types/react@18.2.31)(immer@9.0.15)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - debug
@@ -1732,25 +1732,25 @@ packages:
       - react-native
     dev: false
 
-  /@h5web/h5wasm@10.0.0(@h5web/app@10.0.0)(react@18.2.0)(typescript@4.7.4):
-    resolution: {integrity: sha512-ddK0X55ioao7yE36zYEeVfJf6xpw472/sLKnI844K6426On+9ua9oKkPTZy7YwrUrE8ztUMYoTj/V57xNm0TZA==}
+  /@h5web/h5wasm@10.1.0(@h5web/app@10.1.0)(react@18.2.0)(typescript@4.7.4):
+    resolution: {integrity: sha512-FiAuiGHKSGWW4x3kV7Ezrf5AICLpmw7WvGsY5JerKEb8YqyvbS1jB0mcHcKjYDsDWRVU0xqltRLflCKLGBIVPw==}
     peerDependencies:
-      '@h5web/app': 10.0.0
+      '@h5web/app': 10.1.0
       react: '>=18'
       typescript: '>=4.5'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@h5web/app': 10.0.0(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.7.4)
-      h5wasm: 0.6.2
-      nanoid: 5.0.1
+      '@h5web/app': 10.1.0(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.7.4)
+      h5wasm: 0.7.0
+      nanoid: 5.0.4
       react: 18.2.0
       typescript: 4.7.4
     dev: false
 
-  /@h5web/lib@10.0.0(@react-three/fiber@8.14.1)(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(three@0.156.1)(typescript@4.7.4):
-    resolution: {integrity: sha512-rN0zcvhLCPL+pzZkdpxaelCgA2rQ1RU0wnYfrbOfMQFW9lSxpmLekQcAaN/dJgGSsc7uMQ8qoxglDvkyx18MPA==}
+  /@h5web/lib@10.1.0(@react-three/fiber@8.15.12)(@types/react@18.2.31)(immer@9.0.15)(react-dom@18.2.0)(react@18.2.0)(three@0.159.0)(typescript@4.7.4):
+    resolution: {integrity: sha512-wVZMknpeqjBGrKm8XbuDTkKhv1mNQot0DoPfQmHQWJXzwvL23acD9kCnWpswKkz6R9f2XAdQAYeFPMLmsW5u1g==}
     peerDependencies:
       '@react-three/fiber': '>=8'
       react: '>=18'
@@ -1762,12 +1762,12 @@ packages:
         optional: true
     dependencies:
       '@react-hookz/web': 23.1.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-three/fiber': 8.14.1(react-dom@18.2.0)(react@18.2.0)(three@0.156.1)
-      '@visx/axis': 3.3.0(react@18.2.0)
+      '@react-three/fiber': 8.15.12(react-dom@18.2.0)(react@18.2.0)(three@0.159.0)
+      '@visx/axis': 3.5.0(react@18.2.0)
       '@visx/drag': 3.3.0(react@18.2.0)
-      '@visx/grid': 3.3.0(react@18.2.0)
-      '@visx/scale': 3.3.0
-      '@visx/shape': 3.3.0(react@18.2.0)
+      '@visx/grid': 3.5.0(react@18.2.0)
+      '@visx/scale': 3.5.0
+      '@visx/shape': 3.5.0(react@18.2.0)
       '@visx/tooltip': 3.3.0(react-dom@18.2.0)(react@18.2.0)
       d3-array: 3.2.4
       d3-color: 3.1.0
@@ -1781,14 +1781,14 @@ packages:
       react: 18.2.0
       react-aria-menubutton: 7.0.3(react@18.2.0)
       react-dom: 18.2.0(react@18.2.0)
-      react-icons: 4.11.0(react@18.2.0)
-      react-keyed-flatten-children: 2.2.1(react@18.2.0)
+      react-icons: 4.12.0(react@18.2.0)
+      react-keyed-flatten-children: 3.0.0(react@18.2.0)
       react-measure: 2.5.2(react-dom@18.2.0)(react@18.2.0)
       react-slider: 2.0.4(react@18.2.0)
-      react-window: 1.8.9(react-dom@18.2.0)(react@18.2.0)
-      three: 0.156.1
+      react-window: 1.8.10(react-dom@18.2.0)(react@18.2.0)
+      three: 0.159.0
       typescript: 4.7.4
-      zustand: 4.4.1(@types/react@18.2.31)(immer@9.0.15)(react@18.2.0)
+      zustand: 4.4.7(@types/react@18.2.31)(immer@9.0.15)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -1917,8 +1917,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@react-three/fiber@8.14.1(react-dom@18.2.0)(react@18.2.0)(three@0.156.1):
-    resolution: {integrity: sha512-Ky/FiCyJiyaI8bd+vckzgkHgKDSQDOcSSUVFOHCuCO9XOLb7Ebs6lof2hPpFa1HkaeE5ZIbTWIprvN0QqdPF0w==}
+  /@react-three/fiber@8.15.12(react-dom@18.2.0)(react@18.2.0)(three@0.159.0):
+    resolution: {integrity: sha512-yg0CyXVHIdSbNjM/GAgDrGJnKLTsfTlaR5FoJGEh9IgVKptOoudnFZhBt/Cau4rzx2X6eLmB1+aWOm1dEHSUpg==}
     peerDependencies:
       expo: '>=43.0'
       expo-asset: '>=8.4'
@@ -1944,7 +1944,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.2
       '@types/react-reconciler': 0.26.7
+      '@types/webxr': 0.5.10
       base64-js: 1.5.1
+      buffer: 6.0.3
       its-fine: 1.1.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -1952,7 +1954,7 @@ packages:
       react-use-measure: 2.1.1(react-dom@18.2.0)(react@18.2.0)
       scheduler: 0.21.0
       suspend-react: 0.1.3(react@18.2.0)
-      three: 0.156.1
+      three: 0.159.0
       zustand: 3.7.2(react@18.2.0)
     dev: false
 
@@ -2004,6 +2006,12 @@ packages:
     resolution: {integrity: sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==}
     dev: false
 
+  /@types/d3-geo@3.1.0:
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+    dependencies:
+      '@types/geojson': 7946.0.13
+    dev: false
+
   /@types/d3-interpolate@3.0.1:
     resolution: {integrity: sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==}
     dependencies:
@@ -2045,6 +2053,10 @@ packages:
     resolution: {integrity: sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==}
     dev: true
 
+  /@types/geojson@7946.0.13:
+    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+    dev: false
+
   /@types/json-schema@7.0.14:
     resolution: {integrity: sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==}
     dev: true
@@ -2057,8 +2069,10 @@ packages:
     resolution: {integrity: sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==}
     dev: false
 
-  /@types/node@18.18.6:
-    resolution: {integrity: sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w==}
+  /@types/node@20.10.5:
+    resolution: {integrity: sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/normalize-package-data@2.4.3:
@@ -2102,6 +2116,10 @@ packages:
   /@types/semver@7.5.4:
     resolution: {integrity: sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==}
     dev: true
+
+  /@types/webxr@0.5.10:
+    resolution: {integrity: sha512-n3u5sqXQJhf1CS68mw3Wf16FQ4cRPNBBwdYLFzq3UddiADOim1Pn3Y6PBdDilz1vOJF3ybLxJ8ZEDlLIzrOQZg==}
+    dev: false
 
   /@typescript-eslint/eslint-plugin@5.30.6(@typescript-eslint/parser@5.30.6)(eslint@8.21.0)(typescript@4.7.4):
     resolution: {integrity: sha512-J4zYMIhgrx4MgnZrSDD7sEnQp7FmhKNOaqaOpaoQ/SfdMfRB/0yvK74hTnvH+VQxndZynqs5/Hn4t+2/j9bADg==}
@@ -2304,16 +2322,16 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@visx/axis@3.3.0(react@18.2.0):
-    resolution: {integrity: sha512-O7fPQtpum4NEsb8u2/eTeOSt8CvAczoehVQbJtDLyDNio6yLvytfHtRKxOsl/FHjFnPYgBjkQtwiKiR5oSjP3g==}
+  /@visx/axis@3.5.0(react@18.2.0):
+    resolution: {integrity: sha512-vaY/CGk9+iQL1BFlHd5muIAuAjpPKLwtt6HwpITErW+cImjQJlNgYdgbwDCyuJMmJqXOlC9byWlmF+iI1dOPYg==}
     peerDependencies:
       react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
       '@types/react': 18.2.31
       '@visx/group': 3.3.0(react@18.2.0)
       '@visx/point': 3.3.0
-      '@visx/scale': 3.3.0
-      '@visx/shape': 3.3.0(react@18.2.0)
+      '@visx/scale': 3.5.0
+      '@visx/shape': 3.5.0(react@18.2.0)
       '@visx/text': 3.3.0(react@18.2.0)
       classnames: 2.3.2
       prop-types: 15.8.1
@@ -2359,8 +2377,8 @@ packages:
       '@visx/point': 3.3.0
     dev: false
 
-  /@visx/grid@3.3.0(react@18.2.0):
-    resolution: {integrity: sha512-wHzxevZfNreU21CHA2/CFLwJeBsetwXQJLxYmc2DotTFHn07n3XJtGCjMVdrmUKfoa/N8cPcFBehuWjnWWpXBg==}
+  /@visx/grid@3.5.0(react@18.2.0):
+    resolution: {integrity: sha512-i1pdobTE223ItMiER3q4ojIaZWja3vg46TkS6FotnBZ4c0VRDHSrALQPdi0na+YEgppASWCQ2WrI/vD6mIkhSg==}
     peerDependencies:
       react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
@@ -2368,8 +2386,8 @@ packages:
       '@visx/curve': 3.3.0
       '@visx/group': 3.3.0(react@18.2.0)
       '@visx/point': 3.3.0
-      '@visx/scale': 3.3.0
-      '@visx/shape': 3.3.0(react@18.2.0)
+      '@visx/scale': 3.5.0
+      '@visx/shape': 3.5.0(react@18.2.0)
       classnames: 2.3.2
       prop-types: 15.8.1
       react: 18.2.0
@@ -2390,14 +2408,14 @@ packages:
     resolution: {integrity: sha512-03eBBIJarkmX79WbeEGTUZwmS5/MUuabbiM9KfkGS9pETBTWkp1DZtEHZdp5z34x5TDQVLSi0rk1Plg3/8RtDg==}
     dev: false
 
-  /@visx/scale@3.3.0:
-    resolution: {integrity: sha512-H569k7eQEUcFE/X1Zojcb4rUwxurIU4yso21uAuKvXnZcGpDOTr/3YXXHb1JJqOKfLcZtYZWXok6QVDj5ZGtCw==}
+  /@visx/scale@3.5.0:
+    resolution: {integrity: sha512-xo3zrXV2IZxrMq9Y9RUVJUpd93h3NO/r/y3GVi5F9AsbOzOhsLIbsPkunhO9mpUSR8LZ9TiumLEBrY+3frRBSg==}
     dependencies:
-      '@visx/vendor': 3.3.0
+      '@visx/vendor': 3.5.0
     dev: false
 
-  /@visx/shape@3.3.0(react@18.2.0):
-    resolution: {integrity: sha512-+ojOlcoMnbC16zhwK7HyK4dIB9sUJILQfVNBBNw8TBckCsly+S1WdBKZ+RZvQDppNr2YuiQLsZpr3W9zZJaHtg==}
+  /@visx/shape@3.5.0(react@18.2.0):
+    resolution: {integrity: sha512-DP3t9jBQ7dSE3e6ptA1xO4QAIGxO55GrY/6P+S6YREuQGjZgq20TLYLAsiaoPEzFSS4tp0m12ZTPivWhU2VBTw==}
     peerDependencies:
       react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
@@ -2407,7 +2425,7 @@ packages:
       '@types/react': 18.2.31
       '@visx/curve': 3.3.0
       '@visx/group': 3.3.0(react@18.2.0)
-      '@visx/scale': 3.3.0
+      '@visx/scale': 3.5.0
       classnames: 2.3.2
       d3-path: 1.0.9
       d3-shape: 1.3.7
@@ -2445,13 +2463,14 @@ packages:
       react-use-measure: 2.1.1(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /@visx/vendor@3.3.0:
-    resolution: {integrity: sha512-Xf4ziUWP3oUN/91ROYgJr2JJ6tET+j4jgVfa0Mj9XFpFJeY7U8aEwrNDM2mbR1draktCFNyy/OQAaFa69pr8qQ==}
+  /@visx/vendor@3.5.0:
+    resolution: {integrity: sha512-yt3SEZRVmt36+APsCISSO9eSOtzQkBjt+QRxNRzcTWuzwMAaF3PHCCSe31++kkpgY9yFoF+Gfes1TBe5NlETiQ==}
     dependencies:
       '@types/d3-array': 3.0.3
       '@types/d3-color': 3.1.0
       '@types/d3-delaunay': 6.0.1
       '@types/d3-format': 3.0.1
+      '@types/d3-geo': 3.1.0
       '@types/d3-interpolate': 3.0.1
       '@types/d3-scale': 4.0.2
       '@types/d3-time': 3.0.0
@@ -2460,6 +2479,7 @@ packages:
       d3-color: 3.1.0
       d3-delaunay: 6.0.2
       d3-format: 3.1.0
+      d3-geo: 3.1.0
       d3-interpolate: 3.0.1
       d3-scale: 4.0.2
       d3-time: 3.1.0
@@ -2629,8 +2649,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /axios@1.5.0:
-    resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
+  /axios@1.6.2:
+    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
     dependencies:
       follow-redirects: 1.15.3
       form-data: 4.0.0
@@ -2763,6 +2783,13 @@ packages:
       node-releases: 2.0.13
       update-browserslist-db: 1.0.13(browserslist@4.22.1)
     dev: true
+
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
 
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -2950,6 +2977,13 @@ packages:
   /d3-format@3.1.0:
     resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
     engines: {node: '>=12'}
+    dev: false
+
+  /d3-geo@3.1.0:
+    resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-array: 3.2.4
     dev: false
 
   /d3-interpolate@3.0.1:
@@ -4220,8 +4254,8 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /h5wasm@0.6.2:
-    resolution: {integrity: sha512-aVDa+7MNyfQ2IL/fa5g4YeGZAdahBIAZpjpd/toO9q5yRGxTo2KBwDCxyD/RDFKIvHQMPqOhZaRzoucOSdlPpQ==}
+  /h5wasm@0.7.0:
+    resolution: {integrity: sha512-5nFOpklF0HoYCS4Xd4lbYPl3UHolc1VxtW1nKz5BEYi5pingqVPjJVTwnNiIOqYDKuXmxzYBr2wsV3BxjdVZkw==}
     dev: false
 
   /has-bigints@1.0.2:
@@ -4292,6 +4326,10 @@ packages:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
     dev: true
+
+  /ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: false
 
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -4803,8 +4841,8 @@ packages:
     hasBin: true
     dev: true
 
-  /nanoid@5.0.1:
-    resolution: {integrity: sha512-vWeVtV5Cw68aML/QaZvqN/3QQXc6fBfIieAlu05m7FZW2Dgb+3f0xc0TTxuJW+7u30t7iSDTV/j3kVI0oJqIfQ==}
+  /nanoid@5.0.4:
+    resolution: {integrity: sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==}
     engines: {node: ^18 || >=20}
     hasBin: true
     dev: false
@@ -5208,8 +5246,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-icons@4.11.0(react@18.2.0):
-    resolution: {integrity: sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==}
+  /react-icons@4.12.0(react@18.2.0):
+    resolution: {integrity: sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==}
     peerDependencies:
       react: '*'
     dependencies:
@@ -5235,8 +5273,8 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: false
 
-  /react-keyed-flatten-children@2.2.1(react@18.2.0):
-    resolution: {integrity: sha512-6yBLVO6suN8c/OcJk1mzIrUHdeEzf5rtRVBhxEXAHO49D7SlJ70cG4xrSJrBIAG7MMeQ+H/T151mM2dRDNnFaA==}
+  /react-keyed-flatten-children@3.0.0(react@18.2.0):
+    resolution: {integrity: sha512-tSH6gvOyQjt3qtjG+kU9sTypclL1672yjpVufcE3aHNM0FhvjBUQZqsb/awIux4zEuVC3k/DP4p0GdTT/QUt/Q==}
     peerDependencies:
       react: '>=15.0.0'
     dependencies:
@@ -5333,8 +5371,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-window@1.8.9(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==}
+  /react-window@1.8.10(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==}
     engines: {node: '>8.0.0'}
     peerDependencies:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
@@ -5834,8 +5872,8 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
 
-  /three@0.156.1:
-    resolution: {integrity: sha512-kP7H0FK9d/k6t/XvQ9FO6i+QrePoDcNhwl0I02+wmUJRNSLCUIDMcfObnzQvxb37/0Uc9TDT0T1HgsRRrO6SYQ==}
+  /three@0.159.0:
+    resolution: {integrity: sha512-eCmhlLGbBgucuo4VEA9IO3Qpc7dh8Bd4VKzr7WfW4+8hMcIfoAVi1ev0pJYN9PTTsCslbcKgBwr2wNZ1EvLInA==}
     dev: false
 
   /titleize@3.0.0:
@@ -5953,6 +5991,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
@@ -6159,8 +6201,8 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  /zustand@4.4.1(@types/react@18.2.31)(immer@9.0.15)(react@18.2.0):
-    resolution: {integrity: sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==}
+  /zustand@4.4.7(@types/react@18.2.31)(immer@9.0.15)(react@18.2.0):
+    resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       '@types/react': '>=16.8'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@react-hookz/web':
     specifier: 15.1.0
     version: 15.1.0(react-dom@18.2.0)(react@18.2.0)
+  h5wasm-plugins:
+    specifier: 0.0.3
+    version: 0.0.3
   immer:
     specifier: 9.0.15
     version: 9.0.15
@@ -74,14 +77,17 @@ devDependencies:
     specifier: 4.1.5
     version: 4.1.5
   prettier:
-    specifier: 3.0.3
-    version: 3.0.3
+    specifier: 3.1.1
+    version: 3.1.1
   typescript:
     specifier: 4.7.4
     version: 4.7.4
   vite:
     specifier: 3.1.1
     version: 3.1.1
+  vite-plugin-checker:
+    specifier: 0.6.2
+    version: 0.6.2(eslint@8.21.0)(typescript@4.7.4)(vite@3.1.1)
   vite-plugin-eslint:
     specifier: 1.8.1
     version: 1.8.1(eslint@8.21.0)(vite@3.1.1)
@@ -2528,6 +2534,13 @@ packages:
       uri-js: 4.4.1
     dev: true
 
+  /ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.21.3
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2550,6 +2563,14 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
     dev: true
 
   /argparse@2.0.1:
@@ -2752,6 +2773,11 @@ packages:
     engines: {node: '>=0.6'}
     dev: true
 
+  /binary-extensions@2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+    dev: true
+
   /bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
     engines: {node: '>= 5.10.0'}
@@ -2837,6 +2863,21 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /chokidar@3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -2880,6 +2921,11 @@ packages:
     dependencies:
       delayed-stream: 1.0.0
     dev: false
+
+  /commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+    dev: true
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -4091,6 +4137,15 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /fs-extra@11.2.0:
+    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+    dev: true
+
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -4254,6 +4309,16 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
+  /h5wasm-plugins@0.0.3:
+    resolution: {integrity: sha512-hOI1ERa6QfjrN/AWJW0mqFaAU4D4NtzYXjb03h7f1MufkIzCkYo/bZoB7NZy+Qy9vHsxL31rz7hNlZCPouf+tQ==}
+    dependencies:
+      h5wasm: 0.6.10
+    dev: false
+
+  /h5wasm@0.6.10:
+    resolution: {integrity: sha512-GxBWGVxBftyq67kAbS4WPmTH3a8hGKigdMm+IVJ7tLY7BHj+nqDTUKO9RmmPBHy6Pvq5uW1YpIJr/oGanw+RyQ==}
+    dev: false
+
   /h5wasm@0.7.0:
     resolution: {integrity: sha512-5nFOpklF0HoYCS4Xd4lbYPl3UHolc1VxtW1nKz5BEYi5pingqVPjJVTwnNiIOqYDKuXmxzYBr2wsV3BxjdVZkw==}
     dev: false
@@ -4411,6 +4476,13 @@ packages:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
     dependencies:
       has-bigints: 1.0.2
+    dev: true
+
+  /is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
     dev: true
 
   /is-boolean-object@1.1.2:
@@ -4647,6 +4719,14 @@ packages:
     hasBin: true
     dev: true
 
+  /jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    dev: true
+
   /jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -4716,6 +4796,10 @@ packages:
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
+
+  /lodash.pick@4.4.0:
+    resolution: {integrity: sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==}
     dev: true
 
   /lodash.throttle@4.1.1:
@@ -4879,6 +4963,11 @@ packages:
       resolve: 1.22.8
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
+    dev: true
+
+  /normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /normalize.css@8.0.1:
@@ -5160,8 +5249,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+  /prettier@3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true
@@ -5417,6 +5506,13 @@ packages:
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
+    dev: true
+
+  /readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
     dev: true
 
   /reduce-css-calc@1.3.0:
@@ -5876,6 +5972,10 @@ packages:
     resolution: {integrity: sha512-eCmhlLGbBgucuo4VEA9IO3Qpc7dh8Bd4VKzr7WfW4+8hMcIfoAVi1ev0pJYN9PTTsCslbcKgBwr2wNZ1EvLInA==}
     dev: false
 
+  /tiny-invariant@1.3.1:
+    resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
+    dev: true
+
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -5928,6 +6028,11 @@ packages:
 
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
     dev: true
 
@@ -6024,6 +6129,11 @@ packages:
     resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
     dev: false
 
+  /universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+    dev: true
+
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
@@ -6065,6 +6175,59 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /vite-plugin-checker@0.6.2(eslint@8.21.0)(typescript@4.7.4)(vite@3.1.1):
+    resolution: {integrity: sha512-YvvvQ+IjY09BX7Ab+1pjxkELQsBd4rPhWNw8WLBeFVxu/E7O+n6VYAqNsKdK/a2luFlX/sMpoWdGFfg4HvwdJQ==}
+    engines: {node: '>=14.16'}
+    peerDependencies:
+      eslint: '>=7'
+      meow: ^9.0.0
+      optionator: ^0.9.1
+      stylelint: '>=13'
+      typescript: '*'
+      vite: '>=2.0.0'
+      vls: '*'
+      vti: '*'
+      vue-tsc: '>=1.3.9'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      meow:
+        optional: true
+      optionator:
+        optional: true
+      stylelint:
+        optional: true
+      typescript:
+        optional: true
+      vls:
+        optional: true
+      vti:
+        optional: true
+      vue-tsc:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      commander: 8.3.0
+      eslint: 8.21.0
+      fast-glob: 3.3.1
+      fs-extra: 11.2.0
+      lodash.debounce: 4.0.8
+      lodash.pick: 4.4.0
+      npm-run-path: 4.0.1
+      semver: 7.5.4
+      strip-ansi: 6.0.1
+      tiny-invariant: 1.3.1
+      typescript: 4.7.4
+      vite: 3.1.1
+      vscode-languageclient: 7.0.0
+      vscode-languageserver: 7.0.0
+      vscode-languageserver-textdocument: 1.0.11
+      vscode-uri: 3.0.8
+    dev: true
+
   /vite-plugin-eslint@1.8.1(eslint@8.21.0)(vite@3.1.1):
     resolution: {integrity: sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==}
     peerDependencies:
@@ -6103,6 +6266,46 @@ packages:
       rollup: 2.78.1
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vscode-jsonrpc@6.0.0:
+    resolution: {integrity: sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==}
+    engines: {node: '>=8.0.0 || >=10.0.0'}
+    dev: true
+
+  /vscode-languageclient@7.0.0:
+    resolution: {integrity: sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==}
+    engines: {vscode: ^1.52.0}
+    dependencies:
+      minimatch: 3.1.2
+      semver: 7.5.4
+      vscode-languageserver-protocol: 3.16.0
+    dev: true
+
+  /vscode-languageserver-protocol@3.16.0:
+    resolution: {integrity: sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==}
+    dependencies:
+      vscode-jsonrpc: 6.0.0
+      vscode-languageserver-types: 3.16.0
+    dev: true
+
+  /vscode-languageserver-textdocument@1.0.11:
+    resolution: {integrity: sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==}
+    dev: true
+
+  /vscode-languageserver-types@3.16.0:
+    resolution: {integrity: sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==}
+    dev: true
+
+  /vscode-languageserver@7.0.0:
+    resolution: {integrity: sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==}
+    hasBin: true
+    dependencies:
+      vscode-languageserver-protocol: 3.16.0
+    dev: true
+
+  /vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
     dev: true
 
   /which-boxed-primitive@1.0.2:

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -3,6 +3,7 @@ import { H5WasmProvider } from '@h5web/h5wasm';
 import { suspend } from 'suspend-react';
 
 import { fetchBuffer } from './fetch-utils';
+import { getPlugin } from './plugin-utils';
 import type { H5File } from './stores';
 import { buildMailto, FEEDBACK_MESSAGE } from './utils';
 
@@ -19,7 +20,7 @@ function Viewer(props: Props) {
   const buffer = suspend(fetchBuffer, [resolvedUrl, CACHE_KEY]);
 
   return (
-    <H5WasmProvider filename={name} buffer={buffer}>
+    <H5WasmProvider filename={name} buffer={buffer} getPlugin={getPlugin}>
       <App
         key={resolvedUrl}
         disableDarkMode

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -1,0 +1,30 @@
+// Import compression plugins as static assets (i.e. as URLs)
+// cf. `vite.config.ts` and `src/vite-env.d.ts
+import blosc from 'h5wasm-plugins/plugins/libH5Zblosc.so';
+import bz2 from 'h5wasm-plugins/plugins/libH5Zbz2.so';
+import lz4 from 'h5wasm-plugins/plugins/libH5Zlz4.so';
+import lzf from 'h5wasm-plugins/plugins/libH5Zlzf.so';
+import szf from 'h5wasm-plugins/plugins/libH5Zszf.so';
+import zfp from 'h5wasm-plugins/plugins/libH5Zzfp.so';
+import zstd from 'h5wasm-plugins/plugins/libH5Zzstd.so';
+
+const PLUGINS: Record<string, string> = {
+  blosc,
+  bz2,
+  lz4,
+  lzf,
+  szf,
+  zfp,
+  zstd,
+};
+
+export async function getPlugin(
+  name: string,
+): Promise<ArrayBuffer | undefined> {
+  if (!PLUGINS[name]) {
+    return undefined;
+  }
+
+  const response = await fetch(PLUGINS[name]);
+  return response.arrayBuffer();
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,12 +94,12 @@ Here is some additional context:
       ? `
   - File URL: ${fileOrUrl}`
       : fileOrUrl
-      ? `
+        ? `
   - File name: ${fileOrUrl.name}
   - File URL: ${fileOrUrl.url}
   - Service detected: ${fileOrUrl.service}
   - Resolved URL: ${fileOrUrl.resolvedUrl}`
-      : ''
+        : ''
   }${
     entityPath
       ? `

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,8 @@
 // eslint-disable-next-line spaced-comment
 /// <reference types="vite/client" />
+
+// HDF5 compression plugins
+declare module '*.so' {
+  const src: string;
+  export default src;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,25 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { checker } from 'vite-plugin-checker';
 import eslint from 'vite-plugin-eslint';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   server: { open: true },
-  plugins: [react(), eslint()],
+  plugins: [
+    react(),
+    { ...eslint(), apply: 'serve' }, // dev only to reduce build time
+    { ...checker({ typescript: true }), apply: 'serve' }, // dev only to reduce build time
+  ],
+
+  // Import HDF5 compression plugins as static assets
+  assetsInclude: ['**/*.so'],
 
   // `es2020` required by @h5web/h5wasm for BigInt `123n` notation support
   optimizeDeps: { esbuildOptions: { target: 'es2020' } },
   build: {
     target: 'es2020',
-    sourcemap: true,
+    // Out of memory! https://github.com/vitejs/vite/issues/2433
+    // sourcemap: true,
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,16 @@
 import react from '@vitejs/plugin-react';
-// import type { CSSModulesOptions } from 'vite';
 import { defineConfig } from 'vite';
-import eslintPlugin from 'vite-plugin-eslint';
+import eslint from 'vite-plugin-eslint';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   server: { open: true },
-  preview: { open: true },
-  plugins: [react(), eslintPlugin()],
+  plugins: [react(), eslint()],
 
   // `es2020` required by @h5web/h5wasm for BigInt `123n` notation support
   optimizeDeps: { esbuildOptions: { target: 'es2020' } },
   build: {
     target: 'es2020',
-    // Out of memory! https://github.com/vitejs/vite/issues/2433
-    // sourcemap: true,
+    sourcemap: true,
   },
 });


### PR DESCRIPTION
- Release notes: https://github.com/silx-kit/h5web/releases/tag/v10.1.0
- Supported plugins: **Blosc, bzip2, LZ4, LZF, SZ, ZFP and Zstandard**

You can test this at https://deploy-preview-2--myhdf5.netlify.app/view?url=https%3A%2F%2Fwww.silx.org%2Fpub%2Fh5web%2Ffilters.h5