### PR TITLE
Fix URL encoding of error report for Thunderbird

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,7 +111,9 @@ Thanks,
 << Name >>`;
 
   const params = new URLSearchParams({ subject: `[myHDF5] ${subject}`, body });
-  return `mailto:h5web@esrf.fr?${params.toString()}`;
+  const paramsStr = params.toString().replaceAll('+', '%20'); // use percent encoding for spaces to avoid issues with some email clients
+
+  return `mailto:h5web@esrf.fr?${paramsStr}`;
 }
 
 export const FEEDBACK_MESSAGE = `<<


### PR DESCRIPTION
Thunderbird doesn't seem to convert the plus signs in encoded error report URLs back to spaces, so we end up with unreadable error reports.