### PR TITLE
Improve error handling

### DIFF
--- a/src/ErrorFallback.module.css
+++ b/src/ErrorFallback.module.css
@@ -4,16 +4,19 @@
   overflow: auto;
 }
 
-.error {
+.error,
+.detailedError {
   max-width: 45em;
   color: brown;
 }
 
-.error > p {
+.error > p,
+.detailedError > pre {
   margin: 0 0 1rem;
 }
 
-.error > p:first-child {
+.error > p:first-child,
+.detailedError > summary {
   margin-bottom: 1.5rem;
   font-weight: bold;
 }
@@ -29,6 +32,7 @@
   font-size: 90%;
   font-weight: 600;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .btn:hover {

--- a/src/ErrorFallback.module.css
+++ b/src/ErrorFallback.module.css
@@ -1,5 +1,7 @@
 .root {
+  flex: 1;
   padding: 3rem 4rem;
+  overflow: auto;
 }
 
 .error {

--- a/src/FileErrorFallback.tsx
+++ b/src/FileErrorFallback.tsx
@@ -1,7 +1,7 @@
 import { type FallbackProps } from 'react-error-boundary';
 
 import styles from './ErrorFallback.module.css';
-import { NETWORK_ERROR } from './fetch-utils';
+import { FetchError, NetworkError } from './fetch-utils';
 import HttpErrorMessage from './HttpErrorMessage';
 import { type H5File } from './stores';
 import { buildMailto } from './utils';
@@ -12,37 +12,48 @@ interface Props extends FallbackProps {
 
 function FileErrorFallback(props: Props) {
   const { error, file, resetErrorBoundary } = props;
+
   const msg = error instanceof Error ? error.message : 'Unknown error';
+  const cause = error instanceof Error ? error.cause : undefined;
+
+  const causeMsg =
+    cause && cause instanceof Error && cause.message !== msg
+      ? cause.message
+      : undefined;
 
   return (
     <div className={styles.root}>
-      <div className={styles.error}>
-        {msg === NETWORK_ERROR ? (
-          <>
-            <p>File could not be fetched.</p>
-            <p>
-              Your Internet connection might be down. Otherwise, the hosting
-              server you're trying to reach might not support{' '}
-              <a
-                href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
-                target="_blank"
-                rel="noreferrer"
-              >
-                cross-origin requests
-              </a>{' '}
-              (e.g. GitLab). If that's the case, try downloading the file and
-              opening it as a local file instead.
-            </p>
-          </>
-        ) : (
-          <>
-            <p>{msg}</p>
-            <HttpErrorMessage message={msg} resolvedUrl={file.resolvedUrl} />
-          </>
-        )}
-      </div>
+      {causeMsg ? (
+        <details className={styles.detailedError}>
+          <summary>{msg}</summary>
+          <pre>{causeMsg}</pre>
+        </details>
+      ) : error instanceof NetworkError ? (
+        <div className={styles.error}>
+          <p>File could not be fetched.</p>
+          <p>
+            Your Internet connection may be down, or you may be experiencing a{' '}
+            <a
+              href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
+              target="_blank"
+              rel="noreferrer"
+            >
+              cross-origin request
+            </a>{' '}
+            error. If&nbsp;that's the case, try downloading the file and opening
+            it as a local file instead.
+          </p>
+        </div>
+      ) : (
+        <div className={styles.error}>
+          <p>{msg}</p>
+          {error instanceof FetchError && (
+            <HttpErrorMessage status={error.status} fileUrl={file.url} />
+          )}
+        </div>
+      )}
 
-      {msg === NETWORK_ERROR && (
+      {error instanceof NetworkError && (
         <a
           className={styles.btn}
           href={file.resolvedUrl}
@@ -59,12 +70,13 @@ function FileErrorFallback(props: Props) {
         rel="noreferrer"
         href={buildMailto(
           'Error report',
-          `I encountered the following error on myHDF5: "${msg}"`,
+          `I encountered the following error on myHDF5: "${msg}"${causeMsg ? ` — ${causeMsg}` : ''}`,
           file,
         )}
       >
         Report error
       </a>
+
       <button
         className={styles.btn}
         type="button"
@@ -76,19 +88,21 @@ function FileErrorFallback(props: Props) {
       <details className={styles.debug}>
         <summary>Debug information</summary>
         <ul>
+          <li>Service detected: {file.service}</li>
           <li>
-            Provided URL:{' '}
+            File URL:{' '}
             <a href={file.url} target="_blank" rel="noreferrer">
               {file.url}
             </a>
           </li>
-          <li>
-            Resolved URL:{' '}
-            <a href={file.resolvedUrl} target="_blank" rel="noreferrer">
-              {file.resolvedUrl}
-            </a>
-          </li>
-          <li>Service detected: {file.service}</li>
+          {file.resolvedUrl !== file.url && (
+            <li>
+              Resolved URL:{' '}
+              <a href={file.resolvedUrl} target="_blank" rel="noreferrer">
+                {file.resolvedUrl}
+              </a>
+            </li>
+          )}
         </ul>
         <p className={styles.hint}>
           This information is automatically included in the error report.

--- a/src/FileErrorFallback.tsx
+++ b/src/FileErrorFallback.tsx
@@ -1,11 +1,8 @@
-import { useEffect } from 'react';
 import { type FallbackProps } from 'react-error-boundary';
-import { clear } from 'suspend-react';
 
 import styles from './ErrorFallback.module.css';
 import { NETWORK_ERROR } from './fetch-utils';
 import HttpErrorMessage from './HttpErrorMessage';
-import { CACHE_KEY } from './RemoteFileViewer';
 import { type H5File } from './stores';
 import { buildMailto } from './utils';
 
@@ -16,10 +13,6 @@ interface Props extends FallbackProps {
 function FileErrorFallback(props: Props) {
   const { error, file } = props;
   const msg = error instanceof Error ? error.message : 'Unknown error';
-
-  useEffect(() => {
-    clear([file.resolvedUrl, CACHE_KEY]); // clear suspend cache
-  }, [file]);
 
   return (
     <div className={styles.root}>

--- a/src/FileErrorFallback.tsx
+++ b/src/FileErrorFallback.tsx
@@ -11,7 +11,7 @@ interface Props extends FallbackProps {
 }
 
 function FileErrorFallback(props: Props) {
-  const { error, file } = props;
+  const { error, file, resetErrorBoundary } = props;
   const msg = error instanceof Error ? error.message : 'Unknown error';
 
   return (
@@ -65,6 +65,13 @@ function FileErrorFallback(props: Props) {
       >
         Report error
       </a>
+      <button
+        className={styles.btn}
+        type="button"
+        onClick={() => resetErrorBoundary()}
+      >
+        Retry
+      </button>
 
       <details className={styles.debug}>
         <summary>Debug information</summary>

--- a/src/HttpErrorMessage.tsx
+++ b/src/HttpErrorMessage.tsx
@@ -4,18 +4,18 @@ import { UNSTABLE_URL_REGEX } from './services/RemoteService';
 import { getViewerLink } from './utils';
 
 interface Props {
-  message: string;
-  resolvedUrl: string;
+  status: number;
+  fileUrl: string;
 }
 
 function HttpErrorMessage(props: Props) {
-  const { message, resolvedUrl } = props;
+  const { status, fileUrl } = props;
 
-  if (message.startsWith('400')) {
-    return <p>The URL of the file might be wrong or incomplete.</p>;
+  if (status === 400) {
+    return <p>The URL of the file may be wrong or incomplete.</p>;
   }
 
-  if (message.startsWith('401')) {
+  if (status === 401) {
     return (
       <p>
         Authentication is required to access this file. myHDF5 can only open
@@ -24,21 +24,21 @@ function HttpErrorMessage(props: Props) {
     );
   }
 
-  if (message.startsWith('404')) {
-    return UNSTABLE_URL_REGEX.test(resolvedUrl) ? (
+  if (status === 404) {
+    return UNSTABLE_URL_REGEX.test(fileUrl) ? (
       <p>
         You seem to have provided a repository URL pointing to a development
         branch. Perhaps the file has moved? Try using a permalink instead.
       </p>
     ) : (
       <p>
-        The URL of the file might be wrong or the file might no longer exist at
-        this URL.
+        The URL of the file may be wrong or the file may no longer exist at this
+        URL.
       </p>
     );
   }
 
-  if (message.startsWith('418')) {
+  if (status === 418) {
     return (
       <p>
         Try opening{' '}

--- a/src/LocalFileViewer.tsx
+++ b/src/LocalFileViewer.tsx
@@ -5,8 +5,6 @@ import { getPlugin } from './plugin-utils';
 import { type LocalFile } from './stores';
 import { buildMailto, FEEDBACK_MESSAGE } from './utils';
 
-export const CACHE_KEY = Symbol('bufferFetcher');
-
 interface Props {
   file: LocalFile;
 }

--- a/src/LocalFileViewer.tsx
+++ b/src/LocalFileViewer.tsx
@@ -1,6 +1,8 @@
 import { App } from '@h5web/app';
 import { H5WasmLocalFileProvider } from '@h5web/h5wasm';
+import { ErrorBoundary } from 'react-error-boundary';
 
+import FileErrorFallback from './FileErrorFallback';
 import { getPlugin } from './plugin-utils';
 import { type LocalFile } from './stores';
 import { buildMailto, FEEDBACK_MESSAGE } from './utils';
@@ -15,14 +17,21 @@ function LocalFileViewer(props: Props) {
 
   return (
     <H5WasmLocalFileProvider file={rawFile} getPlugin={getPlugin}>
-      <App
-        key={resolvedUrl}
-        disableDarkMode
-        propagateErrors
-        getFeedbackURL={({ entityPath }) => {
-          return buildMailto('Feedback', FEEDBACK_MESSAGE, file, entityPath);
-        }}
-      />
+      <ErrorBoundary
+        fallbackRender={(fallbackProps) => (
+          <FileErrorFallback file={file} {...fallbackProps} />
+        )}
+        resetKeys={[file]}
+      >
+        <App
+          key={resolvedUrl}
+          disableDarkMode
+          propagateErrors
+          getFeedbackURL={({ entityPath }) => {
+            return buildMailto('Feedback', FEEDBACK_MESSAGE, file, entityPath);
+          }}
+        />
+      </ErrorBoundary>
     </H5WasmLocalFileProvider>
   );
 }

--- a/src/RemoteFileViewer.tsx
+++ b/src/RemoteFileViewer.tsx
@@ -7,7 +7,7 @@ import { getPlugin } from './plugin-utils';
 import { type RemoteFile } from './stores';
 import { buildMailto, FEEDBACK_MESSAGE } from './utils';
 
-export const CACHE_KEY = Symbol('bufferFetcher');
+export const FETCH_BUFFER_KEY = Symbol('fetchBuffer');
 
 interface Props {
   file: RemoteFile;
@@ -17,7 +17,7 @@ function RemoteFileViewer(props: Props) {
   const { file } = props;
   const { name, resolvedUrl } = file;
 
-  const buffer = suspend(fetchBuffer, [resolvedUrl, CACHE_KEY]);
+  const buffer = suspend(fetchBuffer, [resolvedUrl, FETCH_BUFFER_KEY]);
 
   return (
     <H5WasmBufferProvider filename={name} buffer={buffer} getPlugin={getPlugin}>

--- a/src/RemoteFileViewer.tsx
+++ b/src/RemoteFileViewer.tsx
@@ -1,8 +1,10 @@
 import { App } from '@h5web/app';
 import { H5WasmBufferProvider } from '@h5web/h5wasm';
+import { ErrorBoundary } from 'react-error-boundary';
 import { suspend } from 'suspend-react';
 
 import { fetchBuffer } from './fetch-utils';
+import FileErrorFallback from './FileErrorFallback';
 import { getPlugin } from './plugin-utils';
 import { type RemoteFile } from './stores';
 import { buildMailto, FEEDBACK_MESSAGE } from './utils';
@@ -21,14 +23,21 @@ function RemoteFileViewer(props: Props) {
 
   return (
     <H5WasmBufferProvider filename={name} buffer={buffer} getPlugin={getPlugin}>
-      <App
-        key={resolvedUrl}
-        disableDarkMode
-        propagateErrors
-        getFeedbackURL={({ entityPath }) => {
-          return buildMailto('Feedback', FEEDBACK_MESSAGE, file, entityPath);
-        }}
-      />
+      <ErrorBoundary
+        fallbackRender={(fallbackProps) => (
+          <FileErrorFallback file={file} {...fallbackProps} />
+        )}
+        resetKeys={[file]}
+      >
+        <App
+          key={resolvedUrl}
+          disableDarkMode
+          propagateErrors
+          getFeedbackURL={({ entityPath }) => {
+            return buildMailto('Feedback', FEEDBACK_MESSAGE, file, entityPath);
+          }}
+        />
+      </ErrorBoundary>
     </H5WasmBufferProvider>
   );
 }

--- a/src/ResolutionErrorFallback.tsx
+++ b/src/ResolutionErrorFallback.tsx
@@ -1,7 +1,7 @@
 import { type FallbackProps } from 'react-error-boundary';
 
 import styles from './ErrorFallback.module.css';
-import { NETWORK_ERROR } from './fetch-utils';
+import { NetworkError } from './fetch-utils';
 import { buildMailto } from './utils';
 
 interface Props extends FallbackProps {
@@ -16,7 +16,7 @@ function ResolutionErrorFallback(props: Props) {
     <div className={styles.root}>
       <div className={styles.error}>
         <p>{msg}</p>
-        {msg === NETWORK_ERROR && (
+        {error instanceof NetworkError && (
           <p>
             Your Internet connection may be down, or you may be experiencing a{' '}
             <a

--- a/src/ResolutionErrorFallback.tsx
+++ b/src/ResolutionErrorFallback.tsx
@@ -1,11 +1,8 @@
-import { useEffect } from 'react';
 import { type FallbackProps } from 'react-error-boundary';
-import { clear } from 'suspend-react';
 
 import styles from './ErrorFallback.module.css';
 import { NETWORK_ERROR } from './fetch-utils';
 import { buildMailto } from './utils';
-import { CACHE_KEY } from './ViewerContainer';
 
 interface Props extends FallbackProps {
   fileUrl: string;
@@ -14,10 +11,6 @@ interface Props extends FallbackProps {
 function ResolutionErrorFallback(props: Props) {
   const { error, fileUrl } = props;
   const msg = error instanceof Error ? error.message : 'Unknown error';
-
-  useEffect(() => {
-    clear([fileUrl, CACHE_KEY]); // clear suspend cache
-  }, [fileUrl]);
 
   return (
     <div className={styles.root}>

--- a/src/ViewPage.tsx
+++ b/src/ViewPage.tsx
@@ -1,9 +1,10 @@
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Navigate, useSearchParams } from 'react-router-dom';
+import { clear } from 'suspend-react';
 
 import ResolutionErrorFallback from './ResolutionErrorFallback';
-import ViewerContainer from './ViewerContainer';
+import ViewerContainer, { RESOLVE_FILE_URL_KEY } from './ViewerContainer';
 
 function ViewPage() {
   const [searchParams] = useSearchParams();
@@ -19,6 +20,9 @@ function ViewPage() {
         <ResolutionErrorFallback fileUrl={fileUrl} {...props} />
       )}
       resetKeys={[fileUrl]}
+      onError={() => {
+        clear([fileUrl, RESOLVE_FILE_URL_KEY]); // clear suspend cache
+      }}
     >
       <Suspense fallback={null}>
         <ViewerContainer fileUrl={fileUrl} />

--- a/src/ViewerContainer.tsx
+++ b/src/ViewerContainer.tsx
@@ -35,6 +35,10 @@ function ViewerContainer(props: Props) {
     return <Navigate to="/" />;
   }
 
+  if (file.service === FileService.Local) {
+    return <LocalFileViewer file={file} />;
+  }
+
   return (
     <ErrorBoundary
       fallbackRender={(fallbackProps) => (
@@ -46,11 +50,7 @@ function ViewerContainer(props: Props) {
       }}
     >
       <Suspense fallback={null}>
-        {file.service === FileService.Local ? (
-          <LocalFileViewer file={file} />
-        ) : (
-          <RemoteFileViewer file={file} />
-        )}
+        <RemoteFileViewer file={file} />
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/ViewerContainer.tsx
+++ b/src/ViewerContainer.tsx
@@ -1,15 +1,15 @@
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Navigate } from 'react-router-dom';
-import { suspend } from 'suspend-react';
+import { clear, suspend } from 'suspend-react';
 
 import FileErrorFallback from './FileErrorFallback';
 import LocalFileViewer from './LocalFileViewer';
-import RemoteFileViewer from './RemoteFileViewer';
+import RemoteFileViewer, { FETCH_BUFFER_KEY } from './RemoteFileViewer';
 import { FileService, useStore } from './stores';
 import { resolveFileUrl } from './utils';
 
-export const CACHE_KEY = Symbol('resolveFileUrl');
+export const RESOLVE_FILE_URL_KEY = Symbol('resolveFileUrl');
 
 interface Props {
   fileUrl: string;
@@ -23,7 +23,7 @@ function ViewerContainer(props: Props) {
 
   const openedFile = opened.find(({ url }) => url === fileUrl);
   const fileToOpen = !openedFile
-    ? suspend(resolveFileUrl, [fileUrl, CACHE_KEY])
+    ? suspend(resolveFileUrl, [fileUrl, RESOLVE_FILE_URL_KEY])
     : undefined;
 
   if (fileToOpen) {
@@ -41,6 +41,9 @@ function ViewerContainer(props: Props) {
         <FileErrorFallback file={file} {...fallbackProps} />
       )}
       resetKeys={[fileUrl]}
+      onError={() => {
+        clear([file.resolvedUrl, FETCH_BUFFER_KEY]); // clear suspend cache
+      }}
     >
       <Suspense fallback={null}>
         {file.service === FileService.Local ? (

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -1,18 +1,15 @@
-export const NETWORK_ERROR = 'Network Error';
+/* eslint-disable max-classes-per-file */
 
 export async function safeFetch(url: string): Promise<Response> {
   let response;
   try {
     response = await fetch(url);
   } catch {
-    throw new Error(NETWORK_ERROR);
+    throw new NetworkError();
   }
 
   if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`${response.status} ${response.statusText}`, {
-      cause: new Error(text),
-    });
+    throw new FetchError(response.status, response.statusText);
   }
 
   return response;
@@ -21,4 +18,21 @@ export async function safeFetch(url: string): Promise<Response> {
 export async function fetchBuffer(url: string): Promise<ArrayBuffer> {
   const response = await safeFetch(url);
   return response.arrayBuffer();
+}
+
+export class NetworkError extends Error {
+  public constructor() {
+    super('Network Error');
+    this.name = 'NetworkError';
+  }
+}
+
+export class FetchError extends Error {
+  public constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+  ) {
+    super(`Request failed: ${status} ${statusText}`);
+    this.name = 'FetchError';
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,6 +83,8 @@ export function buildMailto(
 ): string {
   const body = `Hi,
 
+<<< Please introduce yourself (name, organisation, scientific field, etc.) >>>
+
 ${message}
 
 Here is some additional context:
@@ -104,10 +106,7 @@ Here is some additional context:
       ? `
   - Entity path: ${entityPath}`
       : ''
-  }
-
-Thanks,
-<< Name >>`;
+  }`;
 
   const params = new URLSearchParams({ subject: `[myHDF5] ${subject}`, body });
   const paramsStr = params.toString().replaceAll('+', '%20'); // use percent encoding for spaces to avoid issues with some email clients


### PR DESCRIPTION
A bit of a clean-up ahead of the H5Web v17 upgrade. I'm fixing an overflow bug, refactoring error boundaries so they are more targeted and predictable, and handling errors propagated from the H5Web viewer a bit better.

After the upgrade, HDF5 errors like the one in the recording below will be properly formatted and the trace will be hidden inside an accordion:

[Screencast from 2026-04-15 17-26-20.webm](https://github.com/user-attachments/assets/5cd3e022-e3ec-4dce-91ef-5a0f95ccb397)

I'm also adding a paragraph at the top of the error report email asking people to introduce themselves, so that we have something more to go on that just people's email addresses.

