### PR TITLE
Ask people to send their local file when reporting errors

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,6 +75,24 @@ export async function resolveFileUrl(
   };
 }
 
+const INTRO =
+  'Please introduce yourself (name, organisation, scientific field, etc.)';
+
+function getReportIntro(fileOrUrl?: H5File | string) {
+  if (
+    fileOrUrl &&
+    typeof fileOrUrl !== 'string' &&
+    fileOrUrl.service === FileService.Local
+  ) {
+    return `<<<
+  1. ${INTRO}
+  2. To help us understand the issue, please send us your HDF5 file (ideally via a file sharing service).
+>>>`;
+  }
+
+  return `<<< ${INTRO} >>>`;
+}
+
 export function buildMailto(
   subject: string,
   message: string,
@@ -83,7 +101,7 @@ export function buildMailto(
 ): string {
   const body = `Hi,
 
-<<< Please introduce yourself (name, organisation, scientific field, etc.) >>>
+${getReportIntro(fileOrUrl)}
 
 ${message}
 


### PR DESCRIPTION
We get error reports mostly for local files, typically because they are malformed. Unfortunately, people tend to leave the email template as is and don't provide us with the file — we have to reply to ask for the file, and even then, people rarely reply.

I'm hoping that this little paragraph at the top of the email template will trigger a bit more forethought from users.