### PR TITLE
Upgrade H5Web to v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "analyze": "pnpm dlx source-map-explorer \"dist/assets/*.js\" --no-border-checks"
   },
   "dependencies": {
-    "@h5web/app": "16.0.1",
-    "@h5web/h5wasm": "16.0.1",
+    "@h5web/app": "17.0.0",
+    "@h5web/h5wasm": "17.0.0",
     "@react-hookz/web": "25.2.0",
-    "h5wasm-plugins": "0.2.0",
+    "h5wasm-plugins": "0.3.0",
     "modern-normalize": "3.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ importers:
   .:
     dependencies:
       '@h5web/app':
-        specifier: 16.0.1
-        version: 16.0.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: 17.0.0
+        version: 17.0.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))
       '@h5web/h5wasm':
-        specifier: 16.0.1
-        version: 16.0.1(@h5web/app@16.0.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1)))(@types/react@18.3.28)(h5wasm-plugins@0.2.0)(react@18.3.1)(typescript@5.9.3)
+        specifier: 17.0.0
+        version: 17.0.0(@h5web/app@17.0.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1)))(@types/react@18.3.28)(h5wasm-plugins@0.3.0(h5wasm@0.10.1))(react@18.3.1)(typescript@5.9.3)
       '@react-hookz/web':
         specifier: 25.2.0
         version: 25.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       h5wasm-plugins:
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.3.0
+        version: 0.3.0(h5wasm@0.10.1)
       modern-normalize:
         specifier: 3.0.1
         version: 3.0.1
@@ -383,8 +383,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.27.16':
-    resolution: {integrity: sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==}
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
@@ -392,8 +392,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@h5web/app@16.0.1':
-    resolution: {integrity: sha512-hOsT3FvMRUghGo4mz4AucOJMaKzYgUFrPG8XKgy51GNYdX7WNJnd9N0T6T4wNVss8eckqn+AMdom7A6hFIBkgg==}
+  '@h5web/app@17.0.0':
+    resolution: {integrity: sha512-HIKNxBsDk1yyL/ntrgo0sXfA2jKYiKAn+EXEXkpw7iLp8gnTHx2UNKwdSFRHaxoZ6QsrQ36a1qCfASsnlJDzog==}
     peerDependencies:
       '@types/react': 18.x
       '@types/react-dom': 18.x
@@ -411,12 +411,12 @@ packages:
       typescript:
         optional: true
 
-  '@h5web/h5wasm@16.0.1':
-    resolution: {integrity: sha512-y3jTnZTa0WB1524PfM26nevR8bHbJh/61T/faqr+tDNkMfSSXPjlUPxCPTx2TnffMoNkgEHxdX7CVl4n4Fb09w==}
+  '@h5web/h5wasm@17.0.0':
+    resolution: {integrity: sha512-FjgiHD5o0qhp7wyZc8qkhXDnwfA4/3o5QgPm1bFkt3HPGvQWOAgEKH/IeKUrMgxlEUL1xnxqEjqrq0s8XvIt1w==}
     peerDependencies:
-      '@h5web/app': 16.0.1
+      '@h5web/app': 17.0.0
       '@types/react': 18.x
-      h5wasm-plugins: 0.2.0
+      h5wasm-plugins: 0.3.0
       react: 18.x
       typescript: '>=4.5'
     peerDependenciesMeta:
@@ -427,8 +427,8 @@ packages:
       typescript:
         optional: true
 
-  '@h5web/lib@16.0.1':
-    resolution: {integrity: sha512-uG8dAgKQKe6I08UZWGzc+d25qW4S97ILLgvMFHyy4fok4scEQClpVQN5VFBIydvrVJdu40bDgGW1DbeSOjRf/A==}
+  '@h5web/lib@17.0.0':
+    resolution: {integrity: sha512-w0g5XnyU4fauZqHbt7IuumJT3BaAbGXV8lAgtYeyxY1OCLme4hKB802u2Qvwn8Epjr/P3T27oITowc4OK/gDWw==}
     peerDependencies:
       '@react-three/fiber': 8.x
       '@types/react': 18.x
@@ -1239,6 +1239,10 @@ packages:
     resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
     engines: {node: '>=12'}
 
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
   d3-geo@3.1.0:
     resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
     engines: {node: '>=12'}
@@ -1676,14 +1680,16 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  h5wasm-plugins@0.2.0:
-    resolution: {integrity: sha512-bT3sW1OSvPBFDCqGYDMyjUIEbDRxx5/8k5AKRYEmog+kW6QIF0MHUhyGNFoeTOvjtjbLYlh6FKcgPiqEE4VLRw==}
+  h5wasm-plugins@0.3.0:
+    resolution: {integrity: sha512-0L3XSaNa44sWQYfyI6b8aNm4uORJaFV9Q/+6DY/4J7M8lyO7B7ZBZCh4D7BVHpIK5XrfensRWOnuXArugMqfaQ==}
+    peerDependencies:
+      h5wasm: ^0.10.1
+    peerDependenciesMeta:
+      h5wasm:
+        optional: true
 
-  h5wasm@0.8.11:
-    resolution: {integrity: sha512-oZ/sZA155VVQl6d37Gay6RnjwGTrS63Lm8wZzhrbRdJr0nAswr9KCmu8qSUMlQn1TSOIK1kEBnpmH2XztwFq6w==}
-
-  h5wasm@0.8.7:
-    resolution: {integrity: sha512-7TJKTSXnZobVZYSywEsy3PnIqTDsyIX8i/WNmtnL6it+K/2OLcjZAg0Fpx+LUjyc9L/HqmWD8qYBd0Nf/dYwZA==}
+  h5wasm@0.10.1:
+    resolution: {integrity: sha512-VxKLoNcPmn/4j6wWuf81gRGzcNjW1aHKtNgRp6ZBeYd6RoWmN3tk5HB6E3nPYsc3YhGT+o07xz1tK6wdMuPMiw==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -2024,9 +2030,6 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash.throttle@4.1.1:
-    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -2085,8 +2088,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.7:
+    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -2241,11 +2244,6 @@ packages:
     peerDependencies:
       react: '>= 16.8 || 18.0.0'
 
-  react-error-boundary@6.0.0:
-    resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
-    peerDependencies:
-      react: '>=16.13.1'
-
   react-error-boundary@6.1.1:
     resolution: {integrity: sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==}
     peerDependencies:
@@ -2276,8 +2274,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-keyed-flatten-children@5.0.1:
-    resolution: {integrity: sha512-bZhTocogwo+q6zz3+HAQexckXhm+Ko8CaujKO6A138kVpRtF4xN8OmLE7F1Qv9YcDJrZ8gPXkJdM/VgcKjJimg==}
+  react-keyed-flatten-children@5.1.1:
+    resolution: {integrity: sha512-+DXMhjG0nbKq7AuWvAp1NUWCcg4jsUuBCdtDW8ySl45m3+MTjbXbR+TxvoM/1dTH7reSDqksBipkc/e/gpUnDg==}
     peerDependencies:
       react: '>=18.0.0'
       react-is: '>=18.0.0'
@@ -2294,10 +2292,11 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
-  react-reflex@4.2.7:
-    resolution: {integrity: sha512-MojP7nzowxoJLGp060fIaQ1oF+Aah/kJn29kotKCmk3fsp2YxO8NmPPoS6XagPe8DAL7PzK6woJ/HlBlW+dSwg==}
+  react-resizable-panels@4.9.0:
+    resolution: {integrity: sha512-sEl+hA6y9/kxa0aPlrUC+G1lcShAf/PiIjoeC8kWXxa53RfAVplVCIxEl01Nwa4L2iRa5JXBXq1/mI8ch6qOZQ==}
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-router-dom@6.3.0:
     resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
@@ -2324,8 +2323,8 @@ packages:
       react-dom:
         optional: true
 
-  react-window@2.2.1:
-    resolution: {integrity: sha512-jrUMKDLW1B4yX4OU0QjdytGgWIg6wqWfiTe86lUhFsCUltkNNB/zYxFU0DTKAzBOMRbkpLVWS1IkLvQeO4L7nw==}
+  react-window@2.2.3:
+    resolution: {integrity: sha512-gTRqQYC8ojbiXyd9duYFiSn2TJw0ROXCgYjenOvNKITWzK0m0eCvkUsEUM08xvydkMh7ncp+LE0uS3DeNGZxnQ==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -2550,8 +2549,8 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
-  three@0.181.0:
-    resolution: {integrity: sha512-KGf6EOCOQGshXeleKxpxhbowQwAXR2dLlD93egHtZ9Qmk07Saf8sXDR+7wJb53Z1ORZiatZ4WGST9UsVxhHEbg==}
+  three@0.182.0:
+    resolution: {integrity: sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -2791,24 +2790,6 @@ packages:
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
-    engines: {node: '>=12.20.0'}
-    peerDependencies:
-      '@types/react': '>=18.0.0'
-      immer: '>=9.0.6'
-      react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-      use-sync-external-store:
-        optional: true
-
-  zustand@5.0.8:
-    resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -3115,7 +3096,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@floating-ui/react@0.27.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@floating-ui/react@0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@floating-ui/utils': 0.2.11
@@ -3125,23 +3106,23 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@h5web/app@16.0.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))':
+  '@h5web/app@17.0.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))':
     dependencies:
-      '@h5web/lib': 16.0.1(@react-three/fiber@8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.181.0))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.181.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))
+      '@h5web/lib': 17.0.0(@react-three/fiber@8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.182.0))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.182.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))
       '@react-hookz/web': 25.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-three/fiber': 8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.181.0)
+      '@react-three/fiber': 8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.182.0)
       '@types/d3-format': 3.0.4
       '@types/ndarray': 1.0.14
-      d3-format: 3.1.0
+      d3-format: 3.1.2
       ndarray: 1.0.19
       ndarray-ops: 1.2.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-error-boundary: 6.0.0(react@18.3.1)
+      react-error-boundary: 6.1.1(react@18.3.1)
       react-icons: 5.4.0(react@18.3.1)
-      react-reflex: 4.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      three: 0.181.0
-      zustand: 5.0.8(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+      react-resizable-panels: 4.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      three: 0.182.0
+      zustand: 5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
@@ -3158,23 +3139,23 @@ snapshots:
       - react-native
       - use-sync-external-store
 
-  '@h5web/h5wasm@16.0.1(@h5web/app@16.0.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1)))(@types/react@18.3.28)(h5wasm-plugins@0.2.0)(react@18.3.1)(typescript@5.9.3)':
+  '@h5web/h5wasm@17.0.0(@h5web/app@17.0.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1)))(@types/react@18.3.28)(h5wasm-plugins@0.3.0(h5wasm@0.10.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@h5web/app': 16.0.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))
+      '@h5web/app': 17.0.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))
       comlink: 4.4.2
-      h5wasm: 0.8.7
-      nanoid: 5.1.6
+      h5wasm: 0.10.1
+      nanoid: 5.1.7
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
-      h5wasm-plugins: 0.2.0
+      h5wasm-plugins: 0.3.0(h5wasm@0.10.1)
       typescript: 5.9.3
 
-  '@h5web/lib@16.0.1(@react-three/fiber@8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.181.0))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.181.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))':
+  '@h5web/lib@17.0.0(@react-three/fiber@8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.182.0))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.182.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))':
     dependencies:
-      '@floating-ui/react': 0.27.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react': 0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-hookz/web': 25.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-three/fiber': 8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.181.0)
+      '@react-three/fiber': 8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.182.0)
       '@types/d3-array': 3.2.2
       '@types/d3-color': 3.1.3
       '@types/d3-format': 3.0.4
@@ -3191,7 +3172,7 @@ snapshots:
       '@visx/tooltip': 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       d3-array: 3.2.4
       d3-color: 3.1.0
-      d3-format: 3.1.0
+      d3-format: 3.1.2
       d3-interpolate: 3.0.1
       d3-scale: 4.0.2
       d3-scale-chromatic: 3.1.0
@@ -3201,12 +3182,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-icons: 5.4.0(react@18.3.1)
       react-is: 18.3.1
-      react-keyed-flatten-children: 5.0.1(react-is@18.3.1)(react@18.3.1)
+      react-keyed-flatten-children: 5.1.1(react-is@18.3.1)(react@18.3.1)
       react-measure: 2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-slider: 2.0.6(react@18.3.1)
-      react-window: 2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      three: 0.181.0
-      zustand: 5.0.8(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+      react-window: 2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      three: 0.182.0
+      zustand: 5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
@@ -3267,7 +3248,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-three/fiber@8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.181.0)':
+  '@react-three/fiber@8.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.182.0)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@types/react-reconciler': 0.26.7
@@ -3280,7 +3261,7 @@ snapshots:
       react-use-measure: 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       scheduler: 0.21.0
       suspend-react: 0.1.3(react@18.3.1)
-      three: 0.181.0
+      three: 0.182.0
       zustand: 3.7.2(react@18.3.1)
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
@@ -3427,7 +3408,7 @@ snapshots:
 
   '@types/d3-scale@4.0.2':
     dependencies:
-      '@types/d3-time': 3.0.0
+      '@types/d3-time': 3.0.4
 
   '@types/d3-scale@4.0.9':
     dependencies:
@@ -4065,6 +4046,8 @@ snapshots:
 
   d3-format@3.1.0: {}
 
+  d3-format@3.1.2: {}
+
   d3-geo@3.1.0:
     dependencies:
       d3-array: 3.2.4
@@ -4083,7 +4066,7 @@ snapshots:
   d3-scale@4.0.2:
     dependencies:
       d3-array: 3.2.4
-      d3-format: 3.1.0
+      d3-format: 3.1.2
       d3-interpolate: 3.0.1
       d3-time: 3.1.0
       d3-time-format: 4.1.0
@@ -4660,13 +4643,11 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  h5wasm-plugins@0.2.0:
-    dependencies:
-      h5wasm: 0.8.11
+  h5wasm-plugins@0.3.0(h5wasm@0.10.1):
+    optionalDependencies:
+      h5wasm: 0.10.1
 
-  h5wasm@0.8.11: {}
-
-  h5wasm@0.8.7: {}
+  h5wasm@0.10.1: {}
 
   has-bigints@1.1.0: {}
 
@@ -4968,8 +4949,6 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash.throttle@4.1.1: {}
-
   lodash@4.18.1: {}
 
   loose-envify@1.4.0:
@@ -5014,7 +4993,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.7: {}
 
   natural-compare@1.4.0: {}
 
@@ -5181,11 +5160,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
 
-  react-error-boundary@6.0.0(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      react: 18.3.1
-
   react-error-boundary@6.1.1(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -5208,7 +5182,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-keyed-flatten-children@5.0.1(react-is@18.3.1)(react@18.3.1):
+  react-keyed-flatten-children@5.1.1(react-is@18.3.1)(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-is: 18.3.1
@@ -5228,15 +5202,10 @@ snapshots:
       react: 18.3.1
       scheduler: 0.21.0
 
-  react-reflex@4.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-resizable-panels@4.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
-      lodash.throttle: 4.1.1
-      prop-types: 15.8.1
       react: 18.3.1
-      react-measure: 2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - react-dom
+      react-dom: 18.3.1(react@18.3.1)
 
   react-router-dom@6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -5261,7 +5230,7 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  react-window@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-window@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -5570,7 +5539,7 @@ snapshots:
 
   tabbable@6.4.0: {}
 
-  three@0.181.0: {}
+  three@0.182.0: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -5772,12 +5741,6 @@ snapshots:
       react: 18.3.1
 
   zustand@5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
-    optionalDependencies:
-      '@types/react': 18.3.28
-      react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
-  zustand@5.0.8(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:
       '@types/react': 18.3.28
       react: 18.3.1

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -1,6 +1,8 @@
-// Import compression plugins as static assets (i.e. as URLs)
-// cf. `vite.config.ts` and `src/vite-env.d.ts
+/* Import compression plugins as static assets (i.e. as URLs)
+ * cf. `vite.config.ts` and `src/vite-env.d.ts */
 import { type Plugin } from '@h5web/h5wasm';
+import bitgroom from 'h5wasm-plugins/plugins/libH5Zbitgroom.so';
+import bitround from 'h5wasm-plugins/plugins/libH5Zbitround.so';
 import blosc from 'h5wasm-plugins/plugins/libH5Zblosc.so';
 import blosc2 from 'h5wasm-plugins/plugins/libH5Zblosc2.so';
 import bshuf from 'h5wasm-plugins/plugins/libH5Zbshuf.so';
@@ -12,6 +14,8 @@ import zfp from 'h5wasm-plugins/plugins/libH5Zzfp.so';
 import zstd from 'h5wasm-plugins/plugins/libH5Zzstd.so';
 
 const PLUGINS = {
+  bitgroom,
+  bitround,
   bshuf,
   blosc,
   blosc2,


### PR DESCRIPTION
**Full release notes:** https://github.com/silx-kit/h5web/releases/tag/v17.0.0

Note that this also improves the display of HDF5 file errors:

<img width="1512" height="651" alt="image" src="https://github.com/user-attachments/assets/c872954f-9fc7-4dce-a720-112e15942c58" />
